### PR TITLE
Add all live pages under dsacms.github.io domain to org profile README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -27,6 +27,7 @@ Establish and maintain guidance, policies, practices, and talent pipelines that 
 - [repo-scaffolder Repository Templates](https://dsacms.github.io/repo-scaffolder)
 - [Metrics Website](https://dsacms.github.io/metrics)
 - [Medicare Monthly Enrollment Dashboard](https://dsacms.github.io/medicare_monthly_enrollment_dashboard/)
+- [OSPO Year in Review](https://dsacms.github.io/year-in-review)
 
 ### SHARE IT Act Stack
 - [SHARE IT Act Landing Page](https://dsacms.github.io/share-it-act-lp)
@@ -36,6 +37,7 @@ Establish and maintain guidance, policies, practices, and talent pipelines that 
 
 ### Resources
 - [OSPO Guide](https://dsacms.github.io/ospo-guide)
+- [Decks](https://www.github.com/DSACMS/decks)
 
 ## CMS OSPO in the News
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -21,6 +21,22 @@ We accomplish these goals by bringing the best and brightest talent from industr
 # What does the Open Source Program Office (OSPO) at CMS do?
 Establish and maintain guidance, policies, practices, and talent pipelines that advance equity, build trust, and amplify impact across CMS, HHS, and Federal Open Source Ecosystems by working and sharing openly. 
 
+## CMS OSPO Projects and Initiatives
+
+### Tools
+- [repo-scaffolder](https://dsacms.github.io/repo-scaffolder)
+- [Metrics Website](https://dsacms.github.io/metrics)
+- [Medicare Monthly Enrollment Dashboard](https://dsacms.github.io/medicare_monthly_enrollment_dashboard/)
+
+### SHARE IT Act Stack
+- [SHARE IT Act Landing Page](https://dsacms.github.io/share-it-act-lp)
+- [code.json Generator](https://dsacms.github.io/codejson-generator/)
+- [code.json Index Generator Website](https://dsacms.github.io/index-generator-website/)
+- [data.json Index Generator Website](https://dsacms.github.io/datajson-index-generator/)
+
+### Resources
+- [OSPO Guide](https://dsacms.github.io/ospo-guide)
+
 ## CMS OSPO in the News
 
 ### 2025

--- a/profile/README.md
+++ b/profile/README.md
@@ -24,7 +24,7 @@ Establish and maintain guidance, policies, practices, and talent pipelines that 
 ## CMS OSPO Projects and Initiatives
 
 ### Tools
-- [repo-scaffolder](https://dsacms.github.io/repo-scaffolder)
+- [repo-scaffolder Repository Templates](https://dsacms.github.io/repo-scaffolder)
 - [Metrics Website](https://dsacms.github.io/metrics)
 - [Medicare Monthly Enrollment Dashboard](https://dsacms.github.io/medicare_monthly_enrollment_dashboard/)
 


### PR DESCRIPTION
## Problem
In [dsacms.github.io](https://www.dsacms.github.io), it does not contain the live pages our tools and websites are hosted on under this domain

## Solution
Add a new section including links to these live pages so users are informed of the various tools and resources that live in dsamcs.github.io
